### PR TITLE
return prepared container in Base function

### DIFF
--- a/golang/main.go
+++ b/golang/main.go
@@ -147,7 +147,7 @@ func (g *Golang) Base(version string) *Golang {
 		WithMountedCache("/go/pkg/mod", mod).
 		WithMountedCache("/root/.cache/go-build", build)
 	g.Ctr = c
-	return g
+	return g.prepare()
 }
 
 // The go build container


### PR DESCRIPTION
I have the following function: 

```go 
// runs `make` with the given arguments
func (m *ClientGolang) Make(
	// +optional
	args string,
	// +default="1.20"
	goVersion string,
) (string, error) {
	return dag.Golang().
		Base(goVersion).
		Container().
		WithMountedDirectory("/src", m.Source).
		WithWorkdir("/src").
		WithEntrypoint([]string{"sh", "-c", "ls -la"}).Stdout(context.Background())
}
```

It'd be nice if `Base` already returned a prepared container so I don't have to call `WithMounted... WithWorkdir...` myself :pray: 