### PR TITLE
fix: revert return type mismatch

### DIFF
--- a/golang/main.go
+++ b/golang/main.go
@@ -147,7 +147,7 @@ func (g *Golang) Base(version string) *Golang {
 		WithMountedCache("/go/pkg/mod", mod).
 		WithMountedCache("/root/.cache/go-build", build)
 	g.Ctr = c
-	return g.prepare()
+	return g
 }
 
 // The go build container


### PR DESCRIPTION
In commit bd3775f attempt was made to have Base() return a "prepared" Container but the return type is *Golang. More changes/testing may be needed to ensure this behavior works everywhere. Currently broken in main, so reverting.