### PR TITLE
chore(proxy): bump engineVersion to v0.19.11

### DIFF
--- a/proxy/dagger.json
+++ b/proxy/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "proxy",
-  "engineVersion": "v0.18.17",
+  "engineVersion": "v0.19.11",
   "sdk": {
     "source": "python"
   }

--- a/proxy/src/main.py
+++ b/proxy/src/main.py
@@ -5,6 +5,8 @@ This module allows you to proxy any number of Dagger Services
 through a single Dagger Service on specified ports
 """
 
+from typing import Optional
+
 import dagger
 from dagger import dag, function, field, object_type
 
@@ -71,13 +73,13 @@ class Proxy:
         name: str,
         frontend: int,
         backend: int,
-        is_tcp: bool = False,
+        is_tcp: Optional[bool] = None,
     ) -> "Proxy":
         """Add a service to proxy"""
-        cfg = get_config(backend, name, frontend, is_tcp)
+        cfg = get_config(backend, name, frontend, is_tcp or False)
         conf_path = (
             f"/etc/nginx/stream.d/{name}.conf"
-            if is_tcp
+            if is_tcp or False
             else f"/etc/nginx/conf.d/{name}.conf"
         )
         self.ctr = (
@@ -93,7 +95,7 @@ class Proxy:
         return self.ctr.as_service(args=["nginx", "-g", "daemon off;"])
 
 
-def get_config(port: int, name: str, frontend: int, is_tcp: bool) -> str:
+def get_config(port: int, name: str, frontend: int, is_tcp: bool | None) -> str:
     if is_tcp:
         return f"""
     server {{


### PR DESCRIPTION
## Why?

Dagger v0.19.11 changed optional argument detection in generated client wrappers ([fix](https://github.com/dagger/dagger/commit/42b4e400d87a2822517b36bc75b0fc89766bb900)). With the proxy module still declaring `engineVersion: v0.18.17`, callers on v0.19.11 would get:

```
FunctionError: Proxy.with_service() got an unexpected keyword argument 'is_tcp'
```

The `is_tcp` parameter exists in source but was dropped from the generated client wrapper due to the old engine version triggering a legacy code generation path.

## This PR will...
* Bump `engineVersion` in `proxy/dagger.json` from `v0.18.17` to `v0.19.11` so the proxy module is generated correctly for callers on current Dagger versions

## Testing
* Verified locally that `dag.proxy().with_service(..., is_tcp=True)` resolves and runs correctly after this change